### PR TITLE
Add XDG support to installer

### DIFF
--- a/fnx/components/io.fnl
+++ b/fnx/components/io.fnl
@@ -2,6 +2,22 @@
 
 (local lfs (require :lfs))
 
+(fn component.directory-for [purpose]
+  (match purpose
+    :data       (component.build-directory "XDG_DATA_HOME" "/.local/share")
+    :config     (component.build-directory "XDG_CONFIG_HOME" "/.config")
+    :executable (component.build-directory nil "/.local/bin")))
+
+(fn component.build-directory [env-var default]
+  (or
+    (when env-var (os.getenv env-var))
+    (.. (component.home-directory) default)))
+
+(fn component.home-directory []
+  (or
+    (os.getenv "HOME")
+    (string.gsub (component.os-output "echo ~") "\n" "")))
+
 (fn component.os-output [command]
   (let [pipe    (io.popen command)
         output  (pipe:read "*a")]
@@ -9,7 +25,6 @@
 
 (fn component.os [command]
   (os.execute command))
-
 
 (fn component.ensure-directory [path]
   (os.execute (.. "mkdir -p " path)))

--- a/fnx/controllers/installer.fnl
+++ b/fnx/controllers/installer.fnl
@@ -25,11 +25,9 @@
     (local setup-config
       (controller/setup.ensure-config! {
         :install-from-path      (.. (component/io.current-directory) "/")
-        :fnx-binary-path        "/usr/local/bin/fnx"
-        :fnx-config-file-path   (.. (or (os.getenv "XDG_CONFIG_HOME")
-                                        (.. (os.getenv "HOME") "/.config")) "/fnx/config.fnl")
-        :fnx-data-directory     (.. (or (os.getenv "XDG_DATA_HOME")
-                                        (.. (os.getenv "HOME") "/.local/share")) "/fnx/")}
+        :fnx-binary-path        (.. (component/io.directory-for :executable) "/fnx")
+        :fnx-config-file-path   (.. (component/io.directory-for :config) "/.fnx.config.fnl")
+        :fnx-data-directory     (.. (component/io.directory-for :data) "/.fnx/")}
         arguments))
 
     (controller/setup.double-check! setup-config arguments)

--- a/fnx/controllers/installer.fnl
+++ b/fnx/controllers/installer.fnl
@@ -26,8 +26,10 @@
       (controller/setup.ensure-config! {
         :install-from-path      (.. (component/io.current-directory) "/")
         :fnx-binary-path        "/usr/local/bin/fnx"
-        :fnx-config-file-path   (.. (string.gsub (component/io.os-output "echo ~") "\n" "") "/.fnx/.fnx.config.fnl")
-        :fnx-data-directory (.. (string.gsub (component/io.os-output "echo ~") "\n" "") "/.fnx/")}
+        :fnx-config-file-path   (.. (or (os.getenv "XDG_CONFIG_HOME")
+                                        (.. (os.getenv "HOME") "/.config")) "/fnx/config.fnl")
+        :fnx-data-directory     (.. (or (os.getenv "XDG_DATA_HOME")
+                                        (.. (os.getenv "HOME") "/.local/share")) "/fnx/")}
         arguments))
 
     (controller/setup.double-check! setup-config arguments)


### PR DESCRIPTION
In an effort to avoid needlessly cluttering my $HOME, the installer should by default ask if you'd like to install to [XDG-compliant](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) directories.