### PR TITLE
Improving paths strategy

### DIFF
--- a/fnx/controllers/debug.fnl
+++ b/fnx/controllers/debug.fnl
@@ -1,0 +1,69 @@
+(local sn (require :supernova))
+(local port/shell-out (require :fnx.ports.out.shell))
+
+(local controller/injection (require :fnx.controllers.injection))
+(local controller/bootstrap (require :fnx.controllers.dsl.bootstrap))
+
+(local logic/dependencies (require :fnx.logic.dependencies))
+(local logic/smk (require :fnx.logic.smk))
+(local helper/list (require :fnx.helpers.list))
+(local helper/fennel (require :fnx.helpers.fennel))
+
+(local controller {})
+
+(fn controller.handle! [arguments]
+  (if (or (. arguments.present :-b))
+    (controller.debug-bootstrap! arguments)
+    (controller.debug-injections! arguments)))
+
+(fn controller.debug-injections! [arguments]
+  (let [injections (controller/injection.build-injections! arguments)]
+    (controller.display! injections controller.injection-label)))
+
+(fn controller.debug-bootstrap! [arguments]
+  (let [injections (controller/bootstrap.build-injections!)]
+    (controller.display! injections controller.bootstrap-label)))
+
+(fn controller.display! [injections label-fn]
+  (let [names (controller.names-summary injections)
+        list  (->> injections
+                (helper/list.insert-between-if
+                  {:destination "" :path ""}
+                  #(not (= (. $1 :destination) (. $2 :destination))))
+                (helper/list.map
+                  #[[(label-fn (. $1 :destination)) "right" (controller.color-for (. $1 :destination))]
+                    [(. $1 :path) "left"]]))]
+
+    (port/shell-out.dispatch!
+      [[:line  names]
+       [:line  ""]
+       [:table list]])))
+
+(fn controller.bootstrap-label [kind]
+  (match kind
+    :package-path "package.path"
+    :fennel-path  "fennel.path"
+    :macro-path   "fennel.macro-path"
+    _             ""))
+
+(fn controller.injection-label [kind]
+  (match kind
+    :package-path "--add-package-path"
+    :fennel-path  "--add-fennel-path"
+    :macro-path   "--add-macro-path"
+    _             ""))
+
+(fn controller.names-summary [injections]
+  (->> injections
+    (helper/list.filter #(not= (. $1 :destination) :macro-path))
+    (helper/list.map #((controller.color-for (. $1 :destination)) (. $1 :identifier)))
+    (helper/list.uniq)
+    (helper/list.join " ")))
+
+(fn controller.color-for [kind]
+  (match kind
+    :package-path #(sn.blue $1)
+    :fennel-path  #(sn.cyan $1)
+    :macro-path   #(sn.magenta $1)))
+
+controller

--- a/fnx/controllers/dep/install.fnl
+++ b/fnx/controllers/dep/install.fnl
@@ -35,8 +35,6 @@
 
     (local cyclic-control {:_any? false})
 
-    (controller.install! not-installed cyclic-control arguments)
-
     (var keep-installing true)
     (var protection 1000)
 

--- a/fnx/controllers/dsl/bootstrap.fnl
+++ b/fnx/controllers/dsl/bootstrap.fnl
@@ -10,33 +10,33 @@
 (local controller {})
 
 (fn controller.handle! [?main-dot-fnx-path]
-  (let [dependencies (controller.build-dependencies ?main-dot-fnx-path)]
+  (let [dependencies (controller.build-injections! ?main-dot-fnx-path)]
     (each [_ dependency (pairs dependencies)]
-      (match (. dependency :language)
-        :fennel (controller.add-fennel-path! (. dependency :path))
-        :lua    (controller.add-lua-path! (. dependency :path))))))
+      (match (. dependency :destination)
+        :fennel-path  (controller.add-fennel-path!  (. dependency :path))
+        :macro-path   (controller.add-macro-path!   (. dependency :path))
+        :package-path (controller.add-package-path! (. dependency :path))))))
 
 (fn controller.add-fennel-path! [path]
   (set fennel.path (.. path ";" fennel.path)))
 
-(fn controller.add-lua-path! [path]
+(fn controller.add-macro-path! [path]
+  (set fennel.macro-path (.. path ";" fennel.macro-path)))
+
+(fn controller.add-package-path! [path]
   (set package.path (.. path ";" package.path)))
 
-(fn controller.build-dependencies [?main-dot-fnx-path]
+(fn controller.build-injections! [?main-dot-fnx-path]
+  (let [dependencies (controller.build-dependencies! ?main-dot-fnx-path)]
+    (logic/dependencies.to-injection dependencies.injections)))
+
+(fn controller.build-dependencies! [?main-dot-fnx-path]
   (let [working-directory (or
                             (logic.working-directory ?main-dot-fnx-path)
                             (component/io.current-directory))
         main-dot-fnx-path (or ?main-dot-fnx-path (.. working-directory "/.fnx.fnl"))
         dependencies      (controller/injection.build-dependencies-from
                             main-dot-fnx-path (os.getenv "FNX_DATA_DIRECTORY"))]
-    (helper/list.map
-       #(match (. $1 :language)
-         :fennel
-           {:language :fennel
-            :path (logic/dependencies.injection-path (. $1 :usage-path) :fnl)}
-         :lua
-           {:language :lua
-            :path (logic/dependencies.injection-path (. $1 :usage-path) :lua)})
-       dependencies.injections)))
+    dependencies))
 
 controller

--- a/fnx/controllers/dsl/debug.fnl
+++ b/fnx/controllers/dsl/debug.fnl
@@ -1,0 +1,44 @@
+(local helper/list (require :fnx.helpers.list))
+
+(local component/io (require :fnx.components.io))
+
+(local controller/bootstrap (require :fnx.controllers.dsl.bootstrap))
+(local controller/dependencies (require :fnx.controllers.dep.dependencies))
+
+(local controller {})
+
+(fn controller.injections [?main-dot-fnx-path]
+  (let [dependencies (controller/bootstrap.build-injections! ?main-dot-fnx-path)]
+    (helper/list.map
+      #{:package     (. $1 :identifier)
+        :destination (controller.bootstrap-label (. $1 :destination))
+        :path        (. $1 :path) }
+      dependencies)))
+
+(fn controller.dot-fnx-path [?main-dot-fnx-path]
+  (or ?main-dot-fnx-path (.. (component/io.current-directory) "/.fnx.fnl")))
+
+(fn controller.packages [?main-dot-fnx-path]
+  (let [dot-fnx-path (controller.dot-fnx-path ?main-dot-fnx-path)
+        dependencies (controller/dependencies.dependencies-for dot-fnx-path)]
+    (helper/list.map
+          #{:package      (. $1 :identifier)
+            :language     (. $1 :language)}
+          dependencies)))
+
+(fn controller.packages-backup [?main-dot-fnx-path]
+  (let [dependencies (controller/bootstrap.build-dependencies! ?main-dot-fnx-path)]
+    (helper/list.map
+          #{:package  (. $1 :identifier)
+            :language (. $1 :language)
+            :path     (. $1 :usage-path)
+          } dependencies.injections)))
+
+(fn controller.bootstrap-label [kind]
+  (match kind
+    :package-path "package.path"
+    :fennel-path  "fennel.path"
+    :macro-path   "fennel.macro-path"
+    _             ""))
+
+controller

--- a/fnx/controllers/help.fnl
+++ b/fnx/controllers/help.fnl
@@ -15,7 +15,7 @@
        [:line "  fnx version"]
        [:line "  fnx dep"]
        [:line "  fnx config"]
-       [:line "  fnx debug [file.fnl]"]
+       [:line "  fnx debug [file.fnl] [-b]"]
        [:line "  fnx env"]
        [:line ""]])))
 

--- a/fnx/helpers/list.fnl
+++ b/fnx/helpers/list.fnl
@@ -1,8 +1,32 @@
+(local fennel {})
 (local helper {})
+
+(fn helper.legacy-pack [...]
+  (let [result [...]]
+    (tset result :n (select "#" ...))
+    result))
+
+(fn helper.pack [...]
+  (let [pack-fn (or (. table :pack) helper.legacy-pack)]
+    (pack-fn ...)))
 
 (fn helper.unpack [...]
   (let [unpack-fn (or (. table :unpack) (. _G :unpack))]
     (unpack-fn ...)))
+
+(fn helper.insert-between-if [to-insert f list]
+  (local result [])
+  (var first true)
+  (var previous nil)
+
+  (each [_ value (pairs list)]
+    (when (not first)
+      (when (f previous value) (table.insert result to-insert)))
+      (table.insert result value)
+    (set previous value)
+    (set first false))
+
+  result)
 
 (fn helper.insert-between [f-before f-after to-insert list]
   (local result list)
@@ -89,5 +113,23 @@
 (fn helper.map [f list]
   (helper.reduce
     #(do (table.insert $1 (f $2)) $1) list []))
+
+(fn helper.concat [...]
+  (let [result []]
+    (each [_ list (ipairs (table.pack ...))]
+      (each [_ value (pairs list)] (table.insert result value)))
+    result))
+
+(fn helper.flatten [lists]
+  (helper.concat (helper.unpack lists)))
+
+(fn helper.uniq [list]
+  (local control {})
+  (local result [])
+  (each [_ value (pairs list)]
+    (when (not (. control value))
+      (table.insert result value)
+      (tset control value true)))
+  result)
 
 helper

--- a/fnx/helpers/list_test.fnl
+++ b/fnx/helpers/list_test.fnl
@@ -23,4 +23,53 @@
    {:color "red"}
    {:color "red"}])
 
+(t.eq (helper.legacy-pack "a" "b" "c")  {1 "a" 2 "b" 3 "c" :n 3})
+
+(t.eq (helper.pack "a" "b" "c") {1 "a" 2 "b" 3 "c" :n 3})
+
+(t.eq (helper.concat ["a" "b"] ["c" "d"] ["e" "f"])  ["a" "b" "c" "d" "e" "f"])
+
+(t.eq (helper.flatten [["a" "b"] ["c" "d"] ["e" "f"]])  ["a" "b" "c" "d" "e" "f"])
+
+(t.eq (helper.sort ["b" "d" "c" "a"]) ["a" "b" "c" "d"])
+
+(t.eq
+  (helper.sort-by :l [{:l "b"} {:l "d"} {:l "c"} {:l "a"}])
+  [{:l "a"} {:l "b"} {:l "c"} {:l "d"}])
+
+(t.eq
+  (helper.filter #(= (. $1 :l) "b") [{:l "b"} {:l "d"} {:l "c"} {:l "a"}])
+  [{:l "b"}])
+
+(t.eq
+  (helper.sort-by-reverse :l [{:l "b"} {:l "d"} {:l "c"} {:l "a"}])
+  [{:l "d"} {:l "c"} {:l "b"} {:l "a"}])
+
+(t.eq
+  (helper.sort-by-f #(. $1 :l) [{:l "b"} {:l "d"} {:l "c"} {:l "a"}])
+  [{:l "a"} {:l "b"} {:l "c"} {:l "d"}])
+
+(t.eq
+  (helper.uniq ["a" "a" "b" "c" "a"])
+  ["a" "b" "c"])
+
+(t.eq
+  (helper.insert-between-if
+    {:custom "empty"}
+    #(not (= (. $1 :color) (. $2 :color)))
+    [{:color "blue"}
+     {:color "blue"}
+     {:color "red"}
+     {:color "red"}
+     {:color "yellow"}
+     {:color "yellow"}])
+  [{:color "blue"}
+   {:color "blue"}
+   {:custom "empty"}
+   {:color "red"}
+   {:color "red"}
+   {:custom "empty"}
+   {:color "yellow"}
+   {:color "yellow"}])
+
 (t.run!)

--- a/fnx/helpers/path.fnl
+++ b/fnx/helpers/path.fnl
@@ -16,6 +16,9 @@
 (fn helper.sanitize [input]
   (-> input (string.gsub "//" "/") (string.gsub "/$" "")))
 
+(fn helper.previous [path]
+  (helper.expand path ".."))
+
 (fn helper.expand [reference path]
   (if (not (string.match reference "^%/"))
     (error (.. "invalid reference path: \"" reference "\"")))

--- a/fnx/helpers/path_test.fnl
+++ b/fnx/helpers/path_test.fnl
@@ -12,6 +12,9 @@
 
 (t.eq (helper.directory "radioactive/pastel_mint.lua") "./radioactive")
 
+(t.eq (helper.previous "/folder/lorem") "/folder")
+(t.eq (helper.previous "/radioactive") "/")
+
 (t.eq
   (helper.expand "/home/blue" "./red/file.lua")
   "/home/blue/red/file.lua")

--- a/fnx/logic/dependencies_test.fnl
+++ b/fnx/logic/dependencies_test.fnl
@@ -2,355 +2,390 @@
 
 (local logic (require :fnx.logic.dependencies))
 
-(t.eq
-  (logic.build "/" "/home/.fnx/" {
-    "package-a" { :fennel/fnx { :path "/lorem" } }
-    "package-b" { :fennel/local "/lorem/amet" }
-    "package-c" { :lua/local "/dolor/sit" }
-    "package-s" {:lua/rock ">= 0.0.2"}})
+(t.eq (logic.injection-paths-for {:identifier :package-a
+                                  :install-from {:mode :local :path :../lorem}
+                                  :language :fennel
+                                  :provider :fnx
+                                  :usage-path :/home/.fnx/packages/package-a/local
+                                  :dot-fnx-candidate-path :/home/.fnx/packages/package-a/local/.fnx.fnl})
+      [{:destination :fennel-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/local/?.fnl}
+       {:destination :fennel-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/local/?.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init-macros.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/package-a/init-macros.fnl}])
 
-  [{:cyclic-key "fnx:/home/.fnx/packages/package-a/local"
-    :dot-fnx-candidate-path "/home/.fnx/packages/package-a/local/.fnx.fnl"
-    :identifier "package-a"
-    :install-from {:mode "local" :path "/lorem" :version "local"}
-    :language "fennel"
-    :provider "fnx"
-    :usage-path "/home/.fnx/packages/package-a/local"}
-   {:cyclic-key "fennel:/lorem/amet"
-    :dot-fnx-candidate-path "/lorem/amet/.fnx.fnl"
-    :identifier "package-b"
-    :language "fennel"
-    :provider "local"
-    :usage-path "/lorem/amet"}
-   {:cyclic-key "lua:/dolor/sit"
-    :dot-fnx-candidate-path "/dolor/sit/.fnx.fnl"
-    :identifier "package-c"
-    :language "lua"
-    :provider "local"
-    :usage-path "/dolor/sit"}
-   {:cyclic-key "rock:package-s"
-    :identifier "package-s"
-    :install-from {:mode "luarocks" :version ">= 0.0.2"}
-    :language "lua"
-    :provider "rock"}])
+(t.eq (logic.injection-paths-for {:cyclic-key "lua:/dolor/sit"
+                                  :dot-fnx-candidate-path :/dolor/sit/.fnx.fnl
+                                  :identifier :package-c
+                                  :language :lua
+                                  :provider :local
+                                  :usage-path :/dolor/sit})
+      [{:destination :package-path
+        :identifier :package-c
+        :path :/dolor/sit/?.lua}
+       {:destination :package-path
+        :identifier :package-c
+        :path :/dolor/?/init.lua}])
 
-(t.eq
-  (logic.build-dependency
-    "package-name" { :fennel/fnx { :path "/lorem" } } "/" "/home/.fnx/")
+(t.eq (logic.build "/" :/home/.fnx/
+                   {:package-a {:fennel/fnx {:path :/lorem}}
+                    :package-b {:fennel/local :/lorem/amet}
+                    :package-c {:lua/local :/dolor/sit}
+                    :package-s {:lua/rock ">= 0.0.2"}})
+      [{:cyclic-key "fnx:/home/.fnx/packages/package-a/local/package-a"
+        :dot-fnx-candidate-path :/home/.fnx/packages/package-a/local/package-a/.fnx.fnl
+        :identifier :package-a
+        :install-from {:mode :local :path :/lorem :version :local}
+        :language :fennel
+        :provider :fnx
+        :usage-path :/home/.fnx/packages/package-a/local/package-a}
+       {:cyclic-key "fennel:/lorem/amet"
+        :dot-fnx-candidate-path :/lorem/amet/.fnx.fnl
+        :identifier :package-b
+        :language :fennel
+        :provider :local
+        :usage-path :/lorem/amet}
+       {:cyclic-key "lua:/dolor/sit"
+        :dot-fnx-candidate-path :/dolor/sit/.fnx.fnl
+        :identifier :package-c
+        :language :lua
+        :provider :local
+        :usage-path :/dolor/sit}
+       {:cyclic-key "rock:package-s"
+        :identifier :package-s
+        :install-from {:mode :luarocks :version ">= 0.0.2"}
+        :language :lua
+        :provider :rock}])
 
-  {:cyclic-key "fnx:/home/.fnx/packages/package-name/local"
-   :dot-fnx-candidate-path "/home/.fnx/packages/package-name/local/.fnx.fnl"
-   :identifier "package-name"
-   :install-from {:mode "local" :path "/lorem" :version "local"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/package-name/local"})
+(t.eq (logic.build-dependency :package-name {:fennel/fnx {:path :/lorem}} "/"
+                              :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/package-name/local/package-name"
+       :dot-fnx-candidate-path :/home/.fnx/packages/package-name/local/package-name/.fnx.fnl
+       :identifier :package-name
+       :install-from {:mode :local :path :/lorem :version :local}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/package-name/local/package-name})
 
-(t.eq
-  (logic.build-dependency
-    "package-name" { :fennel/local "/lorem/amet" } "/" "/home/.fnx/")
+(t.eq (logic.build-dependency :package-name {:fennel/local :/lorem/amet} "/"
+                              :/home/.fnx/)
+      {:cyclic-key "fennel:/lorem/amet"
+       :dot-fnx-candidate-path :/lorem/amet/.fnx.fnl
+       :identifier :package-name
+       :language :fennel
+       :provider :local
+       :usage-path :/lorem/amet})
 
-  {:cyclic-key "fennel:/lorem/amet"
-   :dot-fnx-candidate-path "/lorem/amet/.fnx.fnl"
-   :identifier "package-name"
-   :language "fennel"
-   :provider "local"
-   :usage-path "/lorem/amet"})
+(t.eq (logic.build-dependency :package-name {:lua/local :/dolor/sit} "/"
+                              :/home/.fnx/)
+      {:cyclic-key "lua:/dolor/sit"
+       :dot-fnx-candidate-path :/dolor/sit/.fnx.fnl
+       :identifier :package-name
+       :language :lua
+       :provider :local
+       :usage-path :/dolor/sit})
 
-(t.eq
-  (logic.build-dependency
-    "package-name" { :lua/local "/dolor/sit" } "/" "/home/.fnx/")
+(t.eq (logic.build-dependency :supernova {:lua/rock ">= 0.0.2"} "/"
+                              :/home/.fnx/)
+      {:cyclic-key "rock:supernova"
+       :identifier :supernova
+       :install-from {:mode :luarocks :version ">= 0.0.2"}
+       :language :lua
+       :provider :rock})
 
-  {:cyclic-key "lua:/dolor/sit"
-   :dot-fnx-candidate-path "/dolor/sit/.fnx.fnl"
-   :identifier "package-name"
-   :language "lua"
-   :provider "local"
-   :usage-path "/dolor/sit"})
+(t.eq (logic.injection-candidates [{:identifier :package-a
+                                    :install-from {:mode :local
+                                                   :path :../lorem}
+                                    :language :fennel
+                                    :provider :fnx
+                                    :usage-path :/home/.fnx/packages/package-a/local
+                                    :dot-fnx-candidate-path :/home/.fnx/packages/package-a/local/.fnx.fnl}
+                                   {:identifier :package-b
+                                    :language :fennel
+                                    :provider :local
+                                    :usage-path :/lorem/amet
+                                    :dot-fnx-candidate-path :/lorem/amet/.fnx.fnl}
+                                   {:identifier :package-c
+                                    :language :lua
+                                    :provider :local
+                                    :usage-path :/dolor/sit
+                                    :dot-fnx-candidate-path :/dolor/sit/.fnx.fnl}
+                                   {:identifier :package-s
+                                    :install-from {:mode :luarocks
+                                                   :version ">= 0.0.2"}
+                                    :language :lua
+                                    :provider :rock}])
+      [{:dot-fnx-candidate-path :/home/.fnx/packages/package-a/local/.fnx.fnl
+        :identifier :package-a
+        :install-from {:mode :local :path :../lorem}
+        :language :fennel
+        :provider :fnx
+        :usage-path :/home/.fnx/packages/package-a/local}
+       {:dot-fnx-candidate-path :/lorem/amet/.fnx.fnl
+        :identifier :package-b
+        :language :fennel
+        :provider :local
+        :usage-path :/lorem/amet}
+       {:dot-fnx-candidate-path :/dolor/sit/.fnx.fnl
+        :identifier :package-c
+        :language :lua
+        :provider :local
+        :usage-path :/dolor/sit}])
 
-(t.eq
-  (logic.build-dependency
-    "supernova" {:lua/rock ">= 0.0.2"} "/" "/home/.fnx/")
+(t.eq (logic.to-injection [{:identifier :package-a
+                            :install-from {:mode :local :path :../lorem}
+                            :language :fennel
+                            :provider :fnx
+                            :usage-path :/home/.fnx/packages/package-a/local
+                            :dot-fnx-candidate-path :/home/.fnx/packages/package-a/local/.fnx.fnl}
+                           {:identifier :package-b
+                            :language :fennel
+                            :provider :local
+                            :usage-path :/lorem/amet
+                            :dot-fnx-candidate-path :/lorem/amet/.fnx.fnl}
+                           {:identifier :package-c
+                            :language :lua
+                            :provider :local
+                            :usage-path :/dolor/sit
+                            :dot-fnx-candidate-path :/dolor/sit/.fnx.fnl}])
+      [{:destination :fennel-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/local/?.fnl}
+       {:destination :fennel-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/local/?.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init-macros.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-a
+        :path :/home/.fnx/packages/package-a/package-a/init-macros.fnl}
+       {:destination :fennel-path
+        :identifier :package-b
+        :path :/lorem/amet/?.fnl}
+       {:destination :fennel-path
+        :identifier :package-b
+        :path :/lorem/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-b
+        :path :/lorem/amet/?.fnl}
+       {:destination :macro-path
+        :identifier :package-b
+        :path :/lorem/?/init-macros.fnl}
+       {:destination :macro-path
+        :identifier :package-b
+        :path :/lorem/?/init.fnl}
+       {:destination :macro-path
+        :identifier :package-b
+        :path :/lorem/package-b/init-macros.fnl}
+       {:destination :package-path
+        :identifier :package-c
+        :path :/dolor/sit/?.lua}
+       {:destination :package-path
+        :identifier :package-c
+        :path :/dolor/?/init.lua}])
 
-  {:cyclic-key "rock:supernova"
-   :identifier "supernova"
-   :install-from {:mode "luarocks" :version ">= 0.0.2"}
-   :language "lua"
-   :provider "rock"})
+(t.eq (logic.build "/" :/home/.fnx/
+                   {:pastel_mint {:lua/local :./radioactive/pastel_mint.lua}})
+      [{:cyclic-key "lua:/radioactive/pastel_mint.lua"
+        :dot-fnx-candidate-path :/radioactive/.fnx.fnl
+        :identifier :pastel_mint
+        :language :lua
+        :provider :local
+        :usage-path :/radioactive/pastel_mint.lua}])
 
-(t.eq
-  (logic.injection-candidates [
-    {:identifier "package-a"
-     :install-from {:mode "local" :path "../lorem"}
-     :language "fennel"
-     :provider "fnx"
-     :usage-path "/home/.fnx/packages/package-a/local"
-     :dot-fnx-candidate-path "/home/.fnx/packages/package-a/local/.fnx.fnl"}
-    {:identifier "package-b"
-     :language "fennel"
-     :provider "local"
-     :usage-path "/lorem/amet"
-     :dot-fnx-candidate-path "/lorem/amet/.fnx.fnl"}
-    {:identifier "package-c"
-     :language "lua"
-     :provider "local"
-     :usage-path "/dolor/sit"
-     :dot-fnx-candidate-path "/dolor/sit/.fnx.fnl"}
-    {:identifier "package-s"
-     :install-from {:mode "luarocks" :version ">= 0.0.2"}
-     :language "lua"
-     :provider "rock"}])
+(t.eq (logic.to-injection [{:identifier :pastel_mint
+                            :language :lua
+                            :provider :local
+                            :usage-path :/radioactive/pastel_mint.lua
+                            :dot-fnx-candidate-path :/radioactive/.fnx.fnl}])
+      [{:destination :package-path
+        :identifier :pastel_mint
+        :path :/radioactive/?.lua}
+       {:destination :package-path :identifier :pastel_mint :path :/?/init.lua}])
 
-  [{:dot-fnx-candidate-path "/home/.fnx/packages/package-a/local/.fnx.fnl"
-    :identifier "package-a"
-    :install-from {:mode "local" :path "../lorem"}
-    :language "fennel"
-    :provider "fnx"
-    :usage-path "/home/.fnx/packages/package-a/local"}
-   {:dot-fnx-candidate-path "/lorem/amet/.fnx.fnl"
-    :identifier "package-b"
-    :language "fennel"
-    :provider "local"
-    :usage-path "/lorem/amet"}
-   {:dot-fnx-candidate-path "/dolor/sit/.fnx.fnl"
-    :identifier "package-c"
-    :language "lua"
-    :provider "local"
-    :usage-path "/dolor/sit"}])
+(t.eq (logic.to-injection [{:identifier :pastel-mint
+                            :language :fennel
+                            :provider :local
+                            :usage-path :/radioactive/pastel-mint.fnl
+                            :dot-fnx-candidate-path :/radioactive/.fnx.fnl}])
+      [{:destination :fennel-path
+        :identifier :pastel-mint
+        :path :/radioactive/?.fnl}
+       {:destination :fennel-path :identifier :pastel-mint :path :/?/init.fnl}
+       {:destination :macro-path
+        :identifier :pastel-mint
+        :path :/radioactive/?.fnl}
+       {:destination :macro-path :identifier :pastel-mint :path :/?/init.fnl}
+       {:destination :macro-path :identifier :pastel-mint :path :/?/init.fnl}
+       {:destination :macro-path
+        :identifier :pastel-mint
+        :path :/pastel-mint/init.fnl}])
 
-(t.eq
-  (logic.to-injection [{:identifier "package-a"
-    :install-from {:mode "local" :path "../lorem"}
-    :language "fennel"
-    :provider "fnx"
-    :usage-path "/home/.fnx/packages/package-a/local"
-    :dot-fnx-candidate-path "/home/.fnx/packages/package-a/local/.fnx.fnl"}
-   {:identifier "package-b"
-    :language "fennel"
-    :provider "local"
-    :usage-path "/lorem/amet"
-    :dot-fnx-candidate-path "/lorem/amet/.fnx.fnl"}
-   {:identifier "package-c"
-    :language "lua"
-    :provider "local"
-    :usage-path "/dolor/sit"
-    :dot-fnx-candidate-path "/dolor/sit/.fnx.fnl"}])
+(t.eq (logic.build "/" :/home/.fnx/
+                   {:hello-world {:fennel/fnx {:git/url "https://github.com/me/fnx-hello-world.git"}}})
+      [{:cyclic-key "fnx:/home/.fnx/packages/hello-world/default/hello-world"
+        :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/default/hello-world/.fnx.fnl
+        :identifier :hello-world
+        :install-from {:mode :git
+                       :url "https://github.com/me/fnx-hello-world.git"
+                       :version :default}
+        :language :fennel
+        :provider :fnx
+        :usage-path :/home/.fnx/packages/hello-world/default/hello-world}])
 
-  (.. " --add-fennel-path /home/.fnx/packages/package-a/local/?.fnl "
-      "--add-fennel-path /lorem/amet/?.fnl "
-      "--add-package-path /dolor/sit/?.lua"))
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/github :me/fnx-hello-world}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/default/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/default/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:mode :git
+                      :url "https://github.com/me/fnx-hello-world.git"
+                      :version :default}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/default/hello-world})
 
-(t.eq
-  (logic.build "/" "/home/.fnx/" {
-    "pastel_mint" {:lua/local "./radioactive/pastel_mint.lua"}})
-  [{:cyclic-key "lua:/radioactive/pastel_mint.lua"
-    :dot-fnx-candidate-path "/radioactive/.fnx.fnl"
-    :identifier "pastel_mint"
-    :language "lua"
-    :provider "local"
-    :usage-path "/radioactive/pastel_mint.lua"}])
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/github :me/fnx-hello-world
+                                            :commit :32e81e5ada283b66710b6494638af2c9bc255195}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/32e81e5/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:mode :git
+                      :url "https://github.com/me/fnx-hello-world.git"
+                      :commit :32e81e5ada283b66710b6494638af2c9bc255195
+                      :version :32e81e5}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/32e81e5/hello-world})
 
-(t.eq
-  (logic.to-injection [
-    {:identifier "pastel_mint"
-     :language "lua"
-     :provider "local"
-     :usage-path "/radioactive/pastel_mint.lua"
-     :dot-fnx-candidate-path "/radioactive/.fnx.fnl"}])
-  " --add-package-path /radioactive/?.lua")
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :commit :32e81e5ada283b66710b6494638af2c9bc255195}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/32e81e5/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:commit :32e81e5ada283b66710b6494638af2c9bc255195
+                      :mode :git
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :32e81e5}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/32e81e5/hello-world})
 
-(t.eq
-  (logic.to-injection [
-    {:identifier "pastel-mint"
-     :language "fennel"
-     :provider "local"
-     :usage-path "/radioactive/pastel-mint.fnl"
-     :dot-fnx-candidate-path "/radioactive/.fnx.fnl"}])
-  " --add-fennel-path /radioactive/?.fnl")
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :branch :gb-triggers}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/gb-triggers/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/gb-triggers/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:branch :gb-triggers
+                      :mode :git
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :gb-triggers}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/gb-triggers/hello-world})
 
-(t.eq
-  (logic.build "/" "/home/.fnx/" {
-    :hello-world {:fennel/fnx {:git/url "https://github.com/me/fnx-hello-world.git"}}})
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :branch :gb-triggers
+                                            :commit :32e81e5ada283b66710b6494638af2c9bc255195}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/32e81e5/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:branch :gb-triggers
+                      :commit :32e81e5ada283b66710b6494638af2c9bc255195
+                      :mode :git
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :32e81e5}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/32e81e5/hello-world})
 
-  [{:cyclic-key "fnx:/home/.fnx/packages/hello-world/default"
-    :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/default/.fnx.fnl"
-    :identifier "hello-world"
-    :install-from {:mode "git"
-                   :url "https://github.com/me/fnx-hello-world.git"
-                   :version "default"}
-    :language "fennel"
-    :provider "fnx"
-    :usage-path "/home/.fnx/packages/hello-world/default"}])
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :tag :v0.0.1}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/v0.0.1/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/v0.0.1/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:mode :git
+                      :tag :v0.0.1
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :v0.0.1}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/v0.0.1/hello-world})
 
-(t.eq
-  (logic.build-dependency
-    "hello-world" {:fennel/fnx {:git/github "me/fnx-hello-world"}}
-    "/" "/home/.fnx/")
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :branch :gb-lorem
+                                            :tag :v0.0.1}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/gb-lorem/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/gb-lorem/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:branch :gb-lorem
+                      :mode :git
+                      :tag :v0.0.1
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :gb-lorem}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/gb-lorem/hello-world})
 
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/default"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/default/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:mode "git"
-                  :url "https://github.com/me/fnx-hello-world.git"
-                  :version "default"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/default"})
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/default/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/default/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:mode :git
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :default}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/default/hello-world})
 
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/github "me/fnx-hello-world"
-         :commit "32e81e5ada283b66710b6494638af2c9bc255195"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/32e81e5/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:mode   "git"
-                  :url    "https://github.com/me/fnx-hello-world.git"
-                  :commit "32e81e5ada283b66710b6494638af2c9bc255195"
-                  :version "32e81e5"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/32e81e5"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :commit "32e81e5ada283b66710b6494638af2c9bc255195"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/32e81e5/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:commit "32e81e5ada283b66710b6494638af2c9bc255195"
-                  :mode "git"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "32e81e5"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/32e81e5"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :branch "gb-triggers"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/gb-triggers"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/gb-triggers/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:branch "gb-triggers"
-                  :mode "git"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "gb-triggers"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/gb-triggers"})
-
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :branch "gb-triggers"
-         :commit "32e81e5ada283b66710b6494638af2c9bc255195"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/32e81e5"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/32e81e5/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:branch "gb-triggers"
-                  :commit "32e81e5ada283b66710b6494638af2c9bc255195"
-                  :mode "git"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "32e81e5"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/32e81e5"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :tag "v0.0.1"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/v0.0.1"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/v0.0.1/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:mode "git"
-                  :tag "v0.0.1"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "v0.0.1"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/v0.0.1"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :branch "gb-lorem"
-         :tag "v0.0.1"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/gb-lorem"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/gb-lorem/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:branch "gb-lorem"
-                  :mode "git"
-                  :tag "v0.0.1"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "gb-lorem"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/gb-lorem"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/default"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/default/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:mode "git"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "default"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/default"})
-
-(t.eq
-  (logic.build-dependency
-    "hello-world"
-    { :fennel/fnx
-        {:git/sourcehut "~me/fnx-hello-world"
-         :branch "main"}}
-    "/" "/home/.fnx/")
-
-  {:cyclic-key "fnx:/home/.fnx/packages/hello-world/main"
-   :dot-fnx-candidate-path "/home/.fnx/packages/hello-world/main/.fnx.fnl"
-   :identifier "hello-world"
-   :install-from {:branch "main"
-                  :mode "git"
-                  :url "https://git.sr.ht/~me/fnx-hello-world"
-                  :version "main"}
-   :language "fennel"
-   :provider "fnx"
-   :usage-path "/home/.fnx/packages/hello-world/main"}
-)
+(t.eq (logic.build-dependency :hello-world
+                              {:fennel/fnx {:git/sourcehut "~me/fnx-hello-world"
+                                            :branch :main}}
+                              "/" :/home/.fnx/)
+      {:cyclic-key "fnx:/home/.fnx/packages/hello-world/main/hello-world"
+       :dot-fnx-candidate-path :/home/.fnx/packages/hello-world/main/hello-world/.fnx.fnl
+       :identifier :hello-world
+       :install-from {:branch :main
+                      :mode :git
+                      :url "https://git.sr.ht/~me/fnx-hello-world"
+                      :version :main}
+       :language :fennel
+       :provider :fnx
+       :usage-path :/home/.fnx/packages/hello-world/main/hello-world})
 
 (t.run!)

--- a/fnx/ports/in/dsl.fnl
+++ b/fnx/ports/in/dsl.fnl
@@ -1,7 +1,18 @@
-(local controller (require :fnx.controllers.bootstrap))
+(local controller/bootstrap (require :fnx.controllers.dsl.bootstrap))
+(local controller/debug (require :fnx.controllers.dsl.debug))
 
-(local port {})
+(local port {:debug {}})
 
-(fn port.bootstrap! [?main-dot-fnx-path] (controller.handle! ?main-dot-fnx-path))
+(fn port.bootstrap! [?main-dot-fnx-path]
+   (controller/bootstrap.handle! ?main-dot-fnx-path))
+
+(fn port.debug.injections [?main-dot-fnx-path]
+  (controller/debug.injections ?main-dot-fnx-path))
+
+(fn port.debug.packages [?main-dot-fnx-path]
+  (controller/debug.packages ?main-dot-fnx-path))
+
+(fn port.debug.dot-fnx-path [?main-dot-fnx-path]
+  (controller/debug.dot-fnx-path ?main-dot-fnx-path))
 
 port

--- a/fnx/ports/in/shell.fnl
+++ b/fnx/ports/in/shell.fnl
@@ -6,6 +6,7 @@
 (local controller/env (require :fnx.controllers.env))
 (local controller/help (require :fnx.controllers.help))
 (local controller/injection (require :fnx.controllers.injection))
+(local controller/debug (require :fnx.controllers.debug))
 (local controller/trap (require :fnx.controllers.trap))
 (local controller/version (require :fnx.controllers.version))
 
@@ -18,7 +19,7 @@
   (match (. arguments :command)
     :config  (controller/config.handle!)
     :env     (controller/env.handle!)
-    :debug   (controller/injection.handle! arguments)
+    :debug   (controller/debug.handle! arguments)
     :dep     (port/dep-in.handle! input?)
     :help    (controller/help.handle!)
     :inject  (controller/injection.handle! arguments)

--- a/get-fnx.sh
+++ b/get-fnx.sh
@@ -1,4 +1,10 @@
-git clone git@github.com:gbaptista/fnx.git
+rm -rf fnx
+
+git clone \
+  -c advice.detachedHead=false \
+  --depth 1 \
+  --branch v0.0.3 \
+  git@github.com:gbaptista/fnx.git
 
 cd fnx
 


### PR DESCRIPTION
Support for new standard paths:

- `/?/init.lua`
- `/?/init.fnl`
- `/?/init-macros.fnl`

Debug command improvements:

- Better visualization.
- Bootstrap support.

```
fnx debug
fnx debug -b
```

New DSL to debug inside Fennel code:
```fnl
(local fnx (require :fnx))

(fnx.debug.injections)
(fnx.debug.packages)
(fnx.debug.dot-fnx-path)
```