### PR TITLE
sudo Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A package manager for the [Fennel](https://fennel-lang.org/) language.
   - [Options](#installation-options)
   - [Requirements](#requirements)
 - [Performance](#performance)
+- [sudo](#sudo)
 - [Debugging](#debugging)
   - [Inside Fennel](#inside-fennel)
 - [Development](#development)
@@ -168,7 +169,7 @@ Options for the `fennel run/install.fnl` command:
 - [Unix](https://en.wikipedia.org/wiki/Unix)
   - [`sh`](https://en.wikipedia.org/wiki/Bourne_shell) [`chmod`](https://en.wikipedia.org/wiki/Chmod) `cp` `ln` `ls` `mkdir` `rm`
 
-### Performance
+## Performance
 
 You might not be happy with the performance of the `fnx` command compared to  `fennel`.
 
@@ -187,7 +188,16 @@ Add into your entrypoint source code:
 
 Done. Just run `fennel source.fnl` as usual instead of `fnx source.fnl`.
 
-### Debugging
+## sudo
+
+If you need to use `fnx` with the `sudo` command, you may want to install `fnx` dependencies in the superuser context for a complete experience.
+
+You can do that with:
+```
+sudo fnx sudo
+```
+
+## Debugging
 
 You can run `fnx debug` to understand what exactly is being injected:
 ```sh
@@ -228,7 +238,7 @@ fennel.macro-path /.local/share/.fnx/packages/fspec/default/?/init-macros.fnl
 fennel.macro-path /.local/share/.fnx/packages/fspec/default/?/init.fnl
 ```
 
-#### Inside Fennel
+### Inside Fennel
 
 > **Warning:** The `debug` namespace is for debugging only purposes. Its API is unstable and may change anytime. Please don't use it in a way that your project depends on it.
 
@@ -279,14 +289,14 @@ If you are using a custom `.fnx.fnl` file:
 (fnx.bootstrap! custom-dot-fnx)
 ```
 
-### Development
+## Development
 
 ```
 fnx dep install
 fnx run/test.fnl
 ```
 
-### Not a Roadmap
+## Not a Roadmap
 
 A list of things that I don't have time to do or that just aren't itching me enough to do something about it, but I would like to do it someday, eventually:
 

--- a/fnx/components/io.fnl
+++ b/fnx/components/io.fnl
@@ -29,7 +29,12 @@
 (fn component.ensure-directory [path]
   (os.execute (.. "mkdir -p " path)))
 
-(fn component.current-directory [command]
+(fn component.working-directory []
+  (or
+    (os.getenv "FNX_WORKING_DIRECTORY")
+    (component.current-directory)))
+
+(fn component.current-directory []
   (helper/string.strip (component.os-output "pwd")))
 
 (fn component.exists? [file-path]

--- a/fnx/controllers/debug.fnl
+++ b/fnx/controllers/debug.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 (local port/shell-out (require :fnx.ports.out.shell))
 
 (local component/io (require :fnx.components.io))
@@ -20,7 +20,7 @@
     (controller.debug-injections! arguments)))
 
 (fn controller.dot-fnx! []
-  (let [working-directory (component/io.current-directory)
+  (let [working-directory (component/io.working-directory)
         dot-fnx-path      (.. working-directory "/.fnx.fnl")]
     (if (component/io.exists? dot-fnx-path)
       (port/shell-out.dispatch!

--- a/fnx/controllers/dep.fnl
+++ b/fnx/controllers/dep.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 
@@ -9,7 +9,7 @@
 (local controller {})
 
 (fn controller.fnx-file-exists? [arguments]
-  (let [working-directory (component/io.current-directory)
+  (let [working-directory (component/io.working-directory)
         fnx-file-path     (.. working-directory "/.fnx.fnl")]
     (if (component/io.exists? fnx-file-path)
       true

--- a/fnx/controllers/dep/dependencies.fnl
+++ b/fnx/controllers/dep/dependencies.fnl
@@ -9,9 +9,9 @@
 
 (local controller {})
 
-(fn controller.load-data! [arguments]
-  (let [working-directory (component/io.current-directory)
-        core-fnx     (model/xpackage.load (.. (os.getenv :FNX_CORE_PATH) "/.fnx.fnl"))
+(fn controller.load-data! [arguments ?working-directory]
+  (let [working-directory (or ?working-directory (component/io.working-directory))
+        core-fnx          (model/xpackage.load (.. (os.getenv :FNX_CORE_PATH) "/.fnx.fnl"))
         dependencies
           (->>
             (.. working-directory "/.fnx.fnl")
@@ -68,7 +68,7 @@
         acc))))
 
 (fn controller.dependencies-for [dot-fnx-path]
-  (let [working-directory (component/io.current-directory)]
+  (let [working-directory (component/io.working-directory)]
     (if (or (not dot-fnx-path) (not (component/io.exists? dot-fnx-path)))
       []
       (->>

--- a/fnx/controllers/dep/install.fnl
+++ b/fnx/controllers/dep/install.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 
@@ -20,12 +20,12 @@
 
 (local controller {})
 
-(fn controller.handle! [arguments]
-  (let [{:core-fnx core-fnx
+(fn controller.handle! [arguments ?working-directory]
+  (let [{:core-fnx      core-fnx
          :to-list       to-list
          :installable   installable
-         :not-installed    not-installed}
-          (controller/dependencies.load-data! arguments)]
+         :not-installed not-installed}
+          (controller/dependencies.load-data! arguments ?working-directory)]
 
     (port/shell-out.dispatch!
       [[:line  (logic/version.display core-fnx.version)]
@@ -40,7 +40,7 @@
 
     (while (and keep-installing (> protection 0))
       (set protection (- protection 1))
-      (let [working-directory (component/io.current-directory)
+      (let [working-directory (component/io.working-directory)
             main-dot-fnx-path (.. working-directory "/.fnx.fnl")
             candidates        (. (controller/dependencies.build-from main-dot-fnx-path) :candidates)
             state             (controller/dependencies.retrieve-state! candidates arguments)

--- a/fnx/controllers/dep/install/fnx.fnl
+++ b/fnx/controllers/dep/install/fnx.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 

--- a/fnx/controllers/dep/install/rock.fnl
+++ b/fnx/controllers/dep/install/rock.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 

--- a/fnx/controllers/dep/uninstall.fnl
+++ b/fnx/controllers/dep/uninstall.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 
@@ -16,7 +16,7 @@
 (fn controller.handle! [arguments]
    (let [{:core-fnx core-fnx :to-list  to-list}
           (controller/dependencies.load-data! arguments)
-         working-directory (component/io.current-directory)
+         working-directory (component/io.working-directory)
          main-dot-fnx-path (.. working-directory "/.fnx.fnl")
          dependencies (. (controller/dependencies.build-from main-dot-fnx-path) :candidates)]
 

--- a/fnx/controllers/dsl/bootstrap.fnl
+++ b/fnx/controllers/dsl/bootstrap.fnl
@@ -33,7 +33,7 @@
 (fn controller.build-dependencies! [?main-dot-fnx-path]
   (let [working-directory (or
                             (logic.working-directory ?main-dot-fnx-path)
-                            (component/io.current-directory))
+                            (component/io.working-directory))
         main-dot-fnx-path (or ?main-dot-fnx-path (.. working-directory "/.fnx.fnl"))
         dependencies      (controller/injection.build-dependencies-from
                             main-dot-fnx-path (os.getenv "FNX_DATA_DIRECTORY"))]

--- a/fnx/controllers/dsl/debug.fnl
+++ b/fnx/controllers/dsl/debug.fnl
@@ -16,7 +16,7 @@
       dependencies)))
 
 (fn controller.dot-fnx-path [?main-dot-fnx-path]
-  (or ?main-dot-fnx-path (.. (component/io.current-directory) "/.fnx.fnl")))
+  (or ?main-dot-fnx-path (.. (component/io.working-directory) "/.fnx.fnl")))
 
 (fn controller.packages [?main-dot-fnx-path]
   (let [dot-fnx-path (controller.dot-fnx-path ?main-dot-fnx-path)

--- a/fnx/controllers/injection.fnl
+++ b/fnx/controllers/injection.fnl
@@ -26,12 +26,22 @@
             (helper/list.join " ")))))))
 
 (fn controller.build-injections! [arguments]
-  (let [working-directory (component/io.current-directory)
+  (let [working-directory (component/io.working-directory)
         main-dot-fnx-path (.. working-directory "/.fnx.fnl")
         dependencies      (controller.build-dependencies-from
                             main-dot-fnx-path
-                            (os.getenv "FNX_DATA_DIRECTORY"))]
+                            (os.getenv "FNX_DATA_DIRECTORY")
+                            (controller.self-injection working-directory))]
+
     (logic/dependencies.to-injection dependencies.injections)))
+
+(fn controller.self-injection [working-directory]
+  {:injections [{:cyclic-key (.. "self:" working-directory)
+   :dot-fnx-candidate-path (.. working-directory "/.fnx.fnl")
+   :identifier "fspec"
+   :language "fennel"
+   :provider "local"
+   :usage-path working-directory}] :cyclic-control { :dot-fnx {} :injection {} }})
 
 (fn controller.build-dependencies-from [dot-fnx-path fnx-data-directory ?acc]
   (let [acc (or ?acc {:injections [] :cyclic-control { :dot-fnx {} :injection {} }})]

--- a/fnx/controllers/installer.fnl
+++ b/fnx/controllers/installer.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 

--- a/fnx/controllers/installer/install.fnl
+++ b/fnx/controllers/installer/install.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 

--- a/fnx/controllers/installer/setup.fnl
+++ b/fnx/controllers/installer/setup.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local port/shell-out (require :fnx.ports.out.shell))
 

--- a/fnx/controllers/sudo.fnl
+++ b/fnx/controllers/sudo.fnl
@@ -1,0 +1,13 @@
+(local controller/install (require :fnx.controllers.dep.install))
+
+(local controller {})
+
+(fn controller.handle! [arguments]
+  (table.insert arguments.list "--global")
+  (tset arguments.present "--global" true)
+
+  (controller/install.handle!
+    arguments
+    (string.gsub (os.getenv :FNX_CORE_PATH) "%/$" "")))
+
+controller

--- a/fnx/helpers/supernova.fnl
+++ b/fnx/helpers/supernova.fnl
@@ -1,0 +1,22 @@
+(local styles
+  [:blink :blink-off :bold :bold-off :conceal :crossed-out :crossed-out-off :doubly
+   :doubly-underline :encircled :encircled-off :faint :fraktur :fraktur-off :framed
+   :framed-off :hide :invert :invert-off :italic :italic-off :overlined :overlined-off
+   :proportional :proportional-off :proportional-spacing :proportional-spacing-off
+   :rapid-blink :reset :reveal :reverse :reverse-off :reverse-video :slow-blink
+   :spacing :spacing-off :strike :strike-off :subscript :superscript :underline
+   :underline-off])
+
+(local colors
+  [:black :blue :cyan :green :magenta :red :white :yellow
+   :bright-black :gray :bright-blue :bright-cyan :bright-green :bright-magenta
+   :bright-red :bright-white :bright-yellow
+   :color :gradient])
+
+(local placebo {})
+
+(each [_ key (pairs styles)] (tset placebo key #$1))
+(each [_ key (pairs colors)] (tset placebo key #$1))
+
+(let [(success library) (pcall require :supernova)]
+  (if success library placebo))

--- a/fnx/logic/dep/list.fnl
+++ b/fnx/logic/dep/list.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local helper/list (require :fnx.helpers/list))
 

--- a/fnx/logic/dep/uninstall.fnl
+++ b/fnx/logic/dep/uninstall.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 {:confirm (.. "Are you sure you want to uninstall " (sn.red "all") " dependencies?")
  :luarocks/unsafe {

--- a/fnx/logic/installer.fnl
+++ b/fnx/logic/installer.fnl
@@ -1,4 +1,4 @@
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (local logic {
   :confirm "Proceed with the installation?"

--- a/fnx/logic/version.fnl
+++ b/fnx/logic/version.fnl
@@ -1,6 +1,6 @@
 (local logic {})
 
-(local sn (require :supernova))
+(local sn (require :fnx.helpers.supernova))
 
 (fn logic.display [version]
   (sn.gradient

--- a/fnx/ports/in/shell.fnl
+++ b/fnx/ports/in/shell.fnl
@@ -3,6 +3,7 @@
 (local adapter/argv (require :fnx.adapters.argv))
 
 (local controller/config (require :fnx.controllers.config))
+(local controller/sudo (require :fnx.controllers.sudo))
 (local controller/env (require :fnx.controllers.env))
 (local controller/help (require :fnx.controllers.help))
 (local controller/injection (require :fnx.controllers.injection))
@@ -11,12 +12,13 @@
 (local controller/version (require :fnx.controllers.version))
 
 (local port {
-  :trapable [:config :debug :dep :env :help :version]})
+  :trapable [:config :sudo :debug :dep :env :help :version]})
 
 (fn port.handle! [input?]
   (let [input     (or input? arg)
         arguments (adapter/argv.parse input)]
   (match (. arguments :command)
+    :sudo    (controller/sudo.handle! arguments)
     :config  (controller/config.handle!)
     :env     (controller/env.handle!)
     :debug   (controller/debug.handle! arguments)


### PR DESCRIPTION
Allow `fnx` to run without `supernova` installed.

Provide a command to install requirements in the superuser context: `sudo fnx sudo`

Introducing self-injection capabilities.

Setting the stage for future binaries support with `FNX_WORKING_DIRECTORY`.